### PR TITLE
Unify on docopt-ng

### DIFF
--- a/foss_build/app.py
+++ b/foss_build/app.py
@@ -39,7 +39,7 @@ import sys
 from pathlib import Path
 from typing import List
 
-from docopt import docopt
+from docopt_ng import docopt
 
 # Constants
 DEFAULT_PARALLEL: int = 8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-docopt==0.6.2 ; python_version >= "3.9" and python_version < "4.0" \
-    --hash=sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491
+docopt-ng==0.9.0 ; python_version >= "3.9" and python_version < "4.0" \
+    --hash=sha256:bfe4c8b03f9fca424c24ee0b4ffa84bf7391cb18c29ce0f6a8227a3b01b81ff9


### PR DESCRIPTION
## Summary
- depend on **docopt-ng** in requirements
- adjust import in `foss_build/app.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docopt_ng')*

------
https://chatgpt.com/codex/tasks/task_b_6844020569208326b229181fd86b6c56